### PR TITLE
Feature/OutputLocationを指定できるようにオプション項目を追加

### DIFF
--- a/src/athena-query.ts
+++ b/src/athena-query.ts
@@ -17,6 +17,11 @@ type Options = {
    * The name of the data catalog used in the query execution.
    */
   catalog?: string;
+
+  /**
+   * The location in Amazon S3 where your query and calculation results are stored.
+   */
+  outputLocation?: string;
 };
 
 export class AthenaQuery {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,7 @@
 import type {
   Athena,
   GetQueryResultsCommandOutput,
+  ResultConfiguration,
 } from "@aws-sdk/client-athena";
 
 export type AtheneRecordData = Record<string, string | number | BigInt | null>;
@@ -13,6 +14,7 @@ async function startQueryExecution(params: {
   workgroup?: string;
   db?: string;
   catalog?: string;
+  outputLocation?: string;
 }) {
   const output = await params.athena.startQueryExecution({
     QueryString: params.sql,
@@ -21,6 +23,9 @@ async function startQueryExecution(params: {
     QueryExecutionContext: {
       Database: params.db || "default",
       Catalog: params.catalog,
+    },
+    ResultConfiguration: {
+      OutputLocation: params.outputLocation,
     },
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -258,6 +258,7 @@ test("pass args to sdk", async () => {
     db: "test-db",
     workgroup: "test-workgroup",
     catalog: "test-catalog",
+    outputLocation: "s3//example/path",
   });
   const resultGen = athenaQuery.query("SELECT test FROM test;", {
     executionParameters: ["test", 123, 456n],
@@ -275,6 +276,9 @@ test("pass args to sdk", async () => {
     QueryExecutionContext: {
       Catalog: "test-catalog",
       Database: "test-db",
+    },
+    ResultConfiguration: {
+      OutputLocation: "s3//example/path",
     },
   });
 


### PR DESCRIPTION
# 概要
https://github.com/classmethod/athena-query/issues/10

現状OutputLocationを指定出来ないため、ワークグループのデフォルトOutputLocationを指定していない場合は上記エラーが吐かれる。
指定できるようにオプション項目を追加。

# 参考
https://docs.aws.amazon.com/ja_jp/athena/latest/ug/workgroups-troubleshooting.html
https://docs.aws.amazon.com/ja_jp/athena/latest/APIReference/API_ResultConfiguration.html#athena-Type-ResultConfiguration-OutputLocation
https://docs.aws.amazon.com/ja_jp/athena/latest/ug/querying.html
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-athena/Interface/StartQueryExecutionCommandInput/