### PR TITLE
fix: read correct type definitions when using ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,14 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
fixed #86 

## Summary
Modified package.json to use the appropriate type definition files based on CJS/ESM.
The necessary files have already been output by pnpm build.

## Changes
Modified package.json to use the appropriate type definition files based on CJS/ESM.

## Output Directories (pnpm build)

```
dist
├── index.cjs
├── index.d.cts
├── index.d.mts
├── index.d.ts
└── index.mjs
```

<details><summary>Japanese</summary>

## 概要

`package.json` を修正し、CJS/ESM に応じた型定義ファイルを使用するようにしました。
必要なファイルはすでに pnpm build で出力されています。

## 変更内容
CJS/ESM に応じた型定義ファイルを使用する形に `package.json` を修正

## 出力されたディレクトリ (pnpm build)

```
dist
├── index.cjs
├── index.d.cts
├── index.d.mts
├── index.d.ts
└── index.mjs
```

</details>